### PR TITLE
Gemfile: update ruby version to match vagrant box

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.0.0'
+ruby '2.1.1'
 gem 'rails', '4.1.5'
 gem 'sqlite3'
 gem 'sass-rails', '~> 4.0.3'


### PR DESCRIPTION
Using a fresh VM configured with the class Vagrantfile, I get this error:

```
vagrant@rails-dev-box:/vagrant/proj1$ bundle install        
Your Ruby version is 2.1.1, but your Gemfile specified 2.0.0
```

I think maybe the project is intended to use [the same version](https://github.com/rails-decal/rails-dev-box/blob/master/puppet/manifests/default.pp#L7) as installed by Vagrant?
